### PR TITLE
Make default values of ContentKey valid

### DIFF
--- a/cpix/content_key.py
+++ b/cpix/content_key.py
@@ -89,6 +89,9 @@ class ContentKey(CPIXComparableBase):
 
     @common_encryption_scheme.setter
     def common_encryption_scheme(self, common_encryption_scheme):
+        if common_encryption_scheme is None:
+            common_encryption_scheme = "cenc"
+
         if isinstance(common_encryption_scheme, bytes):
             common_encryption_scheme = str(common_encryption_scheme)
         if isinstance(
@@ -106,11 +109,12 @@ class ContentKey(CPIXComparableBase):
 
     @explicit_iv.setter
     def explicit_iv(self, explicit_iv):
+        if explicit_iv is None:
+            return
         if isinstance(explicit_iv, (str, bytes)):
             try:
                 b64decode(explicit_iv)
             except BinasciiError:
-                print(explicit_iv)
                 raise ValueError("explicit_iv is not a valid base64 string")
             self._explicit_iv = explicit_iv
         else:


### PR DESCRIPTION
Hi,
I found this issue when calling `cpix.ContentKey` with default values of `explicit_iv` and/or `common_encryption_scheme` params. Default values are not accepted as valid. 

Tested on versions 1.1.0 and 1.1.1.
```
$ ipython
Python 3.8.1 (default, Feb 11 2020, 22:31:52)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.12.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import cpix

In [2]: cpix.ContentKey(
   ...:             kid="0DC3EC4F-7683-548B-81E7-3C64E582E136",
   ...:             cek="WADwG2qCqkq5TVml+U5PXw=="
   ...:         )
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-a0b2a4fb633a> in <module>
----> 1 cpix.ContentKey(
      2             kid="0DC3EC4F-7683-548B-81E7-3C64E582E136",
      3             cek="WADwG2qCqkq5TVml+U5PXw=="
      4         )

~/Documents/github.com/pycpix/cpix/content_key.py in __init__(self, kid, cek, common_encryption_scheme, explicit_iv)
     53         self.kid = kid
     54         self.cek = cek
---> 55         self.common_encryption_scheme = common_encryption_scheme
     56         self.explicit_iv = explicit_iv
     57

~/Documents/github.com/pycpix/cpix/content_key.py in common_encryption_scheme(self, common_encryption_scheme)
     97             self._common_encryption_scheme = common_encryption_scheme
     98         else:
---> 99             raise TypeError(
    100                 "common_encryption_scheme must be: cenc, cbc1, cens or cbcs"
    101             )

TypeError: common_encryption_scheme must be: cenc, cbc1, cens or cbcs

In [3]: cpix.ContentKey(
   ...:             kid="0DC3EC4F-7683-548B-81E7-3C64E582E136",
   ...:             cek="WADwG2qCqkq5TVml+U5PXw==",
   ...:             common_encryption_scheme='cenc',
   ...:         )
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-57ca6f7dadca> in <module>
----> 1 cpix.ContentKey(
      2             kid="0DC3EC4F-7683-548B-81E7-3C64E582E136",
      3             cek="WADwG2qCqkq5TVml+U5PXw==",
      4             common_encryption_scheme='cenc',
      5         )

~/Documents/github.com/pycpix/cpix/content_key.py in __init__(self, kid, cek, common_encryption_scheme, explicit_iv)
     54         self.cek = cek
     55         self.common_encryption_scheme = common_encryption_scheme
---> 56         self.explicit_iv = explicit_iv
     57
     58     @property

~/Documents/github.com/pycpix/cpix/content_key.py in explicit_iv(self, explicit_iv)
    115             self._explicit_iv = explicit_iv
    116         else:
--> 117             raise TypeError("explicit_iv should be a base64 string")
    118
    119     def element(self):

TypeError: explicit_iv should be a base64 string
```