### PR TITLE
Make key optional in ContentKey

### DIFF
--- a/cpix/content_key.py
+++ b/cpix/content_key.py
@@ -45,7 +45,7 @@ class ContentKey(CPIXComparableBase):
         Data: data element containing content encryption key
     """
 
-    def __init__(self, kid, cek, common_encryption_scheme=None, explicit_iv=None):
+    def __init__(self, kid, cek=None, common_encryption_scheme=None, explicit_iv=None):
         self._kid = None
         self._cek = None
         self._common_encryption_scheme = None
@@ -74,6 +74,8 @@ class ContentKey(CPIXComparableBase):
 
     @cek.setter
     def cek(self, cek):
+        if cek is None:
+            return
         if isinstance(cek, (str, bytes)):
             try:
                 b64decode(cek)
@@ -128,14 +130,15 @@ class ContentKey(CPIXComparableBase):
             el.set("commonEncryptionScheme", self.common_encryption_scheme)
         if self.explicit_iv:
             el.set("explicitIV", self.explicit_iv)
-        data = etree.SubElement(el, "Data", nsmap=NSMAP)
-        secret = etree.SubElement(
-            data, "{{{pskc}}}Secret".format(pskc=PSKC), nsmap=NSMAP
-        )
-        plain_value = etree.SubElement(
-            secret, "{{{pskc}}}PlainValue".format(pskc=PSKC), nsmap=NSMAP
-        )
-        plain_value.text = self.cek
+        if self.cek:
+            data = etree.SubElement(el, "Data", nsmap=NSMAP)
+            secret = etree.SubElement(
+                data, "{{{pskc}}}Secret".format(pskc=PSKC), nsmap=NSMAP
+            )
+            plain_value = etree.SubElement(
+                secret, "{{{pskc}}}PlainValue".format(pskc=PSKC), nsmap=NSMAP
+            )
+            plain_value.text = self.cek
         return el
 
     @staticmethod

--- a/tests/test_cpix.py
+++ b/tests/test_cpix.py
@@ -70,6 +70,20 @@ def test_content_key_kid_uuid():
         b'<ContentKey xmlns="urn:dashif:org:cpix" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc" kid="0dc3ec4f-7683-548b-81e7-3c64e582e136" commonEncryptionScheme="cenc"><Data><pskc:Secret><pskc:PlainValue>WADwG2qCqkq5TVml+U5PXw==</pskc:PlainValue></pskc:Secret></Data></ContentKey>'
     )
 
+def test_content_key_no_cek():
+    content_key = cpix.ContentKey(
+        kid=UUID("0DC3EC4F-7683-548B-81E7-3C64E582E136")
+    )
+
+    assert content_key.kid == UUID("0DC3EC4F-7683-548B-81E7-3C64E582E136")
+    assert content_key.cek == None
+
+    xml = etree.tostring(content_key.element())
+
+    assert xml == (
+        b'<ContentKey xmlns="urn:dashif:org:cpix" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc" kid="0dc3ec4f-7683-548b-81e7-3c64e582e136" commonEncryptionScheme="cenc"/>'
+    )
+
 
 def test_content_key_list():
     content_key_list = cpix.ContentKeyList(


### PR DESCRIPTION
In order to build CPIX request documents using pycpix, it's necessary to be able to generate ContentKey elements without a key. Eg:

```
full_cpix = cpix.CPIX(
    content_keys=cpix.ContentKeyList(
        cpix.ContentKey(
            kid="0DC3EC4F-7683-548B-81E7-3C64E582E136"
        )
    ),
    drm_systems=cpix.DRMSystemList(
        cpix.DRMSystem(
            kid="0DC3EC4F-7683-548B-81E7-3C64E582E136",
            system_id="EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED"
        )
    )
)
```