### PR TITLE
Allow documents containing Content Keys with no cek to be parsed correctly

### DIFF
--- a/cpix/content_key.py
+++ b/cpix/content_key.py
@@ -150,7 +150,8 @@ class ContentKey(CPIXComparableBase):
             xml = etree.fromstring(xml)
 
         kid = xml.attrib["kid"]
-        cek = xml.find("**/{{{pskc}}}PlainValue".format(pskc=PSKC)).text
+        cek_elem = xml.find("**/{{{pskc}}}PlainValue".format(pskc=PSKC))
+        cek = cek_elem.text if cek_elem is not None else None
         common_encryption_scheme = None
         explicit_iv = None
 

--- a/tests/test_cpix.py
+++ b/tests/test_cpix.py
@@ -84,6 +84,16 @@ def test_content_key_no_cek():
         b'<ContentKey xmlns="urn:dashif:org:cpix" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc" kid="0dc3ec4f-7683-548b-81e7-3c64e582e136" commonEncryptionScheme="cenc"/>'
     )
 
+def test_parse_content_key_no_cek():
+    kid = UUID("0DC3EC4F-7683-548B-81E7-3C64E582E136")
+    content_key = cpix.ContentKey(
+        kid=kid
+    )
+
+    result = cpix.parse(etree.tostring(content_key.element()))
+
+    assert result.kid == kid
+    assert result.cek == None
 
 def test_content_key_list():
     content_key_list = cpix.ContentKeyList(


### PR DESCRIPTION
When making changes to make Content Key CEK optional in #3, I neglected to change the element xml parser to allow these documents to be parsed in 🤦 