### PR TITLE
Fix linter complaint about == None

### DIFF
--- a/cpix/cpix.py
+++ b/cpix/cpix.py
@@ -86,7 +86,7 @@ class CPIX(CPIXComparableBase):
     def content_id(self, content_id):
         if isinstance(content_id, str):
             self._content_id = content_id
-        elif content_id == None:
+        elif content_id is None:
             self._content_id = None
         else:
             raise TypeError("content_id should be a string")
@@ -99,7 +99,7 @@ class CPIX(CPIXComparableBase):
     def version(self, version):
         if isinstance(version, str):
             self._version = version
-        elif version == None:
+        elif version is None:
             self._version = None
         else:
             raise TypeError("version should be a string")

--- a/tests/test_cpix.py
+++ b/tests/test_cpix.py
@@ -76,7 +76,7 @@ def test_content_key_no_cek():
     )
 
     assert content_key.kid == UUID("0DC3EC4F-7683-548B-81E7-3C64E582E136")
-    assert content_key.cek == None
+    assert content_key.cek is None
 
     xml = etree.tostring(content_key.element())
 
@@ -93,7 +93,7 @@ def test_parse_content_key_no_cek():
     result = cpix.parse(etree.tostring(content_key.element()))
 
     assert result.kid == kid
-    assert result.cek == None
+    assert result.cek is None
 
 def test_content_key_list():
     content_key_list = cpix.ContentKeyList(


### PR DESCRIPTION
I ran Flake8 while I was doing some other changes and noticed that in changes for #3 and #5 I had put `== None` rather than `is None`, so a quick and fairly pointless change for that.