### PR TITLE
Fix parsing and dumping of boolean values in VideoFilter.

### DIFF
--- a/cpix/filters.py
+++ b/cpix/filters.py
@@ -13,6 +13,8 @@ def parse_xsboolean(value):
         return False
     elif value in ALLOWABLE_XSBOOLEAN_TRUE_VALUES:
         return True
+    else:
+        raise ValueError(f"Invalid xs:boolean value: {value}")
 
 
 def encode_bool(value):

--- a/cpix/filters.py
+++ b/cpix/filters.py
@@ -4,6 +4,16 @@ Filter classes
 from . import etree
 from .base import CPIXComparableBase
 
+ALLOWABLE_XSBOOLEAN_TRUE_VALUES = ["true", "1"]
+ALLOWABLE_XSBOOLEAN_FALSE_VALUES = ["false", "0"]
+
+
+def parse_xsboolean(value):
+    if value in ALLOWABLE_XSBOOLEAN_FALSE_VALUES:
+        return False
+    elif value in ALLOWABLE_XSBOOLEAN_TRUE_VALUES:
+        return True
+
 
 def encode_bool(value):
     """Encode booleans to produce valid XML"""
@@ -106,9 +116,9 @@ class VideoFilter(CPIXComparableBase):
         if "maxPixels" in xml.attrib:
             max_pixels = xml.attrib["maxPixels"]
         if "hdr" in xml.attrib:
-            hdr = xml.attrib["hdr"]
+            hdr = parse_xsboolean(xml.attrib["hdr"])
         if "wcg" in xml.attrib:
-            wcg = xml.attrib["wcg"]
+            wcg = parse_xsboolean(xml.attrib["wcg"])
         if "minFps" in xml.attrib:
             min_fps = xml.attrib["minFps"]
         if "maxFps" in xml.attrib:

--- a/tests/test_cpix.py
+++ b/tests/test_cpix.py
@@ -39,6 +39,23 @@ def test_two_video_filters():
     )
 
 
+def test_dumping_bool_in_video_filter():
+    xml = b'<VideoFilter hdr="true" wcg="false"/>'
+
+    vf = cpix.parse(xml)
+
+    assert etree.tostring(vf.element()) == xml
+
+
+def test_parsing_bool_in_video_filter():
+    xml = b'<VideoFilter hdr="true" wcg="false"/>'
+
+    vf = cpix.parse(xml)
+
+    assert vf.wcg == False
+    assert vf.hdr == True
+
+
 def test_content_key_kid_str():
     content_key = cpix.ContentKey(
         kid="0DC3EC4F-7683-548B-81E7-3C64E582E136",

--- a/tests/test_cpix.py
+++ b/tests/test_cpix.py
@@ -52,8 +52,14 @@ def test_parsing_bool_in_video_filter():
 
     vf = cpix.parse(xml)
 
-    assert vf.wcg == False
-    assert vf.hdr == True
+    assert vf.wcg is False
+    assert vf.hdr is True
+
+
+def test_parsing_invalid_bool_in_video_filter():
+    xml = b'<VideoFilter hdr="bar" wcg="foo"/>'
+    with pytest.raises(ValueError):
+        vf = cpix.parse(xml)
 
 
 def test_content_key_kid_str():


### PR DESCRIPTION
Previously, when an existing document was parsed and dumped, these values would be set to 'true' since they were always truthy. Now, parse valid xs:boolean values and set to True or False so they are dumped correctly.

Spotted this when testing with one of the dashif test vectors.