### PR TITLE
Output CPIX elements in schema order

### DIFF
--- a/cpix/cpix.py
+++ b/cpix/cpix.py
@@ -122,14 +122,14 @@ class CPIX(CPIXComparableBase):
                 isinstance(self.drm_systems, DRMSystemList) and
                 len(self.drm_systems) > 0):
             el.append(self.drm_systems.element())
-        if (self.usage_rules is not None and
-                isinstance(self.usage_rules, UsageRuleList) and
-                len(self.usage_rules) > 0):
-            el.append(self.usage_rules.element())
         if (self.periods is not None and
                 isinstance(self.periods, PeriodList) and
                 len(self.periods) > 0):
             el.append(self.periods.element())
+        if (self.usage_rules is not None and
+                isinstance(self.usage_rules, UsageRuleList) and
+                len(self.usage_rules) > 0):
+            el.append(self.usage_rules.element())
         return el
 
     @staticmethod


### PR DESCRIPTION
CpixType children are in a xs:sequence, meaning that element order is important for validation.

This swaps the period and usage rules such that a document containing both will validate.